### PR TITLE
Don't create segments for conflict summary output

### DIFF
--- a/powerline_svnstatus/segments.py
+++ b/powerline_svnstatus/segments.py
@@ -65,7 +65,7 @@ class SvnStatusSegment(Segment):
     (like {'A+': 2, '!C': 1, 'D': 3}).
     '''
     def parse_status(self, lines):
-        return Counter([re.sub(r' +', '', x[0:7]) for x in lines if not re.match(r'       |$|Performing', x)])
+        return Counter([re.sub(r' +', '', x[0:7]) for x in lines if not re.match(r'       |$|Performing|^Summary of conflicts|^  Text conflicts', x)])
 
     '''
     Returns true if the parsed status chars from `svn status` indicate


### PR DESCRIPTION
The `parse_status` method doesn't screen out the conflict summary info that can appear at the bottom of `svn status` output. This change adds two more regex filters to avoid creating segments for the conflict summary lines as shown below.

This `svn status` output:

```
...
C     file.txt
Summary of conflicts:
  Text conflicts: 1
```

Will create the following powerline segments:

```
user@host > trunk > Text 1 > C 1 > Summary 1 >
```

With this change, the segments will be as follows instead:

```
user@host > trunk > C 1 >
```
