### PR TITLE
Emit errors via powerline logger

### DIFF
--- a/powerline_svnstatus/segments.py
+++ b/powerline_svnstatus/segments.py
@@ -99,7 +99,8 @@ class SvnStatusSegment(Segment):
         out, err = self.execute_info(pl, segment_info)
         if err:
             for e in err:
-                pl.error(e)
+                if not e.endswith('is not a working copy'):
+                    pl.error(e)
             return
 
         # if `svn info` doesn't error, display segment for branch
@@ -113,7 +114,8 @@ class SvnStatusSegment(Segment):
         out, err = self.execute_status(pl, segment_info)
         if err:
             for e in err:
-                pl.error(e)
+                if not e.endswith('is not a working copy'):
+                    pl.error(e)
             return
         if not out: return segments
 

--- a/powerline_svnstatus/segments.py
+++ b/powerline_svnstatus/segments.py
@@ -97,7 +97,10 @@ class SvnStatusSegment(Segment):
         segments = []
 
         out, err = self.execute_info(pl, segment_info)
-        if err: return
+        if err:
+            for e in err:
+                pl.error(e)
+            return
 
         # if `svn info` doesn't error, display segment for branch
         branch = self.parse_info(out, branch_re)
@@ -108,7 +111,10 @@ class SvnStatusSegment(Segment):
         })
 
         out, err = self.execute_status(pl, segment_info)
-        if err: return
+        if err:
+            for e in err:
+                pl.error(e)
+            return
         if not out: return segments
 
         counts = self.parse_status(out)


### PR DESCRIPTION
Errors in __call__ are currently ignored, masking issues with parsing the output of `svn info` and `svn status`. In my case, a filename encoding issue caused the entire svn segment to disappear without any indication as to why.

This PR changes error handling so any errors from the svn sub-commands are logged via the powerline logger before returning.

Using the default logging settings, the filename encoding issue mentioned above will be printed to stderr like this:

```
2016-10-25 10:58:06,883:ERROR:shell:svnstatus:svn: E000022: Error converting entry in directory '/foo/bar' to UTF-8
2016-10-25 10:58:06,883:ERROR:shell:svnstatus:svn: E000022: Can't convert string from native encoding to 'UTF-8':
2016-10-25 10:58:06,883:ERROR:shell:svnstatus:svn: E000022: baz?\195?Y?�?
```
