### PR TITLE
Add `branch_format` and `line_start` options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name         = 'powerline-svnstatus',
     description  = 'A Powerline segment for showing the status of a Subversion working directory',
-    version      = '0.4',
+    version      = '0.5',
     keywords     = 'powerline svn status prompt',
     license      = 'MIT',
     author       = 'Justin Ludwig',


### PR DESCRIPTION
This closes #7.

The added options make the segment more flexible. Functionality is not affected and all changes are backwards compatible, because the default values for the new options are exactly the previous hard coded values.

Documentation in `segments.py` is updated, but the README is not. First want to see if this is a welcome change.

Any feedback is much appreciated!