### PR TITLE
Fix powerline ascii-issues when used via the daemon

### DIFF
--- a/powerline_svnstatus/segments.py
+++ b/powerline_svnstatus/segments.py
@@ -18,6 +18,7 @@ class SvnStatusSegment(Segment):
     '''
     def make_env(self, segment_info):
         myenv = segment_info['environ'].copy()
+        myenv['PS1'] = ''
         myenv['LANG'] = 'C'
         myenv['LC_MESSAGES'] = 'C'
         return myenv


### PR DESCRIPTION
When used with powerline-daemon the plugin fails with UnicodeEncodeError: 'ascii' codec can't encode characters in position 34-36: ordinal not in range(128) from subprocess.py.

This can easily be fixed by removing the PS1 with non-ascii characters from the environment.